### PR TITLE
Fix sidebar width during table scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,8 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 
 .logo {

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -24,15 +24,15 @@ export default function Layout({ children, title }) {
   }, [darkMode]);
 
   return (
-    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 grid grid-cols-[auto_1fr]">
       <Sidebar 
         collapsed={collapsed} 
         setCollapsed={setCollapsed}
       />
       
-      <div className="flex-1 flex flex-col">
+      <div className="flex flex-col min-w-0 overflow-hidden">
         <Header title={title} />
-        <main className="flex-1 p-6">
+        <main className="flex-1 p-6 overflow-auto">
           {children}
         </main>
         <Footer />

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -26,7 +26,7 @@ export default function Sidebar({ collapsed, setCollapsed }) {
   };
 
   return (
-    <div className={`${collapsed ? 'w-16' : 'w-64'} bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 min-h-screen flex flex-col transition-all duration-300 ease-in-out overflow-y-auto scrollbar-hide`}>
+    <div className={`${collapsed ? 'w-16' : 'w-64'} bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 min-h-screen flex flex-col transition-all duration-300 ease-in-out overflow-y-auto scrollbar-hide flex-shrink-0`}>
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
         {!collapsed && (

--- a/src/index.css
+++ b/src/index.css
@@ -76,3 +76,30 @@ table {
 .scrollbar-hide::-webkit-scrollbar {
   display: none;  /* Safari and Chrome */
 }
+
+/* Thin scrollbars for table overflow */
+.scrollbar-thin {
+  scrollbar-width: thin;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.scrollbar-thumb-gray-300::-webkit-scrollbar-thumb {
+  background-color: #d1d5db;
+  border-radius: 4px;
+}
+
+.scrollbar-track-gray-100::-webkit-scrollbar-track {
+  background-color: #f3f4f6;
+}
+
+.dark .scrollbar-thumb-gray-600::-webkit-scrollbar-thumb {
+  background-color: #4b5563;
+}
+
+.dark .scrollbar-track-gray-800::-webkit-scrollbar-track {
+  background-color: #1f2937;
+}

--- a/src/pages/Inventory.jsx
+++ b/src/pages/Inventory.jsx
@@ -295,8 +295,9 @@ export default function Inventory() {
 
       {/* Inventory Table */}
       <div className="bg-white dark:bg-gray-800 shadow-sm rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-gray-100 dark:scrollbar-track-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 w-max"
+                 style={{ minWidth: '1200px' }}>
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">

--- a/src/pages/Invoices.jsx
+++ b/src/pages/Invoices.jsx
@@ -248,8 +248,9 @@ export default function Invoices() {
 
       {/* Invoices Table */}
       <div className="bg-white dark:bg-gray-800 shadow-sm rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-gray-100 dark:scrollbar-track-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 w-max"
+                 style={{ minWidth: '1200px' }}>
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">

--- a/src/pages/Quotations.jsx
+++ b/src/pages/Quotations.jsx
@@ -181,8 +181,9 @@ export default function Quotations() {
 
       {/* Quotations Table */}
       <div className="bg-white dark:bg-gray-800 shadow-sm rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-gray-100 dark:scrollbar-track-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 w-max"
+                 style={{ minWidth: '1200px' }}>
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">

--- a/src/pages/SalesOrders.jsx
+++ b/src/pages/SalesOrders.jsx
@@ -184,8 +184,9 @@ export default function SalesOrders() {
 
       {/* Sales Orders Table */}
       <div className="bg-white dark:bg-gray-800 shadow-sm rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-gray-100 dark:scrollbar-track-gray-800">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 w-max"
+                 style={{ minWidth: '1200px' }}>
             <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">


### PR DESCRIPTION
Fixes sidebar width and enables horizontal scrolling for tables to prevent layout shifts when table content is wide.

---
[Slack Thread](https://votrworkspace.slack.com/archives/D09446J3Y2W/p1756466980030119?thread_ts=1756466980.030119&cid=D09446J3Y2W)

<a href="https://cursor.com/background-agent?bcId=bc-2c3d5d97-97b2-4563-90ed-fc3bc47e93e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c3d5d97-97b2-4563-90ed-fc3bc47e93e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

